### PR TITLE
임시 페이지 카드 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "react/no-unescaped-entities": "error",
     "react/react-in-jsx-scope": "off",
     "no-alert": "off",
+    "@typescript-eslint/no-inferrable-types": "warn",
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/naming-convention": [

--- a/src/app/_components/PageList.tsx
+++ b/src/app/_components/PageList.tsx
@@ -14,13 +14,15 @@ function PageList({ recordMap }: Props) {
   const postSummaries = NotionAdapter.getPostSummaries(recordMap);
 
   return (
-    <>
-      {postSummaries?.map(({ id }) => (
+    <article className="flex flex-col gap-1">
+      {postSummaries?.map(({ id, title }) => (
         <Link key={id} href={`/${id}`}>
-          go to {id}
+          <div className="px-[20px] border border-solid border-blue-50 rounded w-1/2 h-[50px]">
+            <h1 className="text-base">{title}</h1>
+          </div>
         </Link>
       ))}
-    </>
+    </article>
   );
 }
 

--- a/src/app/_components/PageList.tsx
+++ b/src/app/_components/PageList.tsx
@@ -11,11 +11,11 @@ interface Props {
 }
 
 function PageList({ recordMap }: Props) {
-  const pageIds = NotionAdapter.getPageIds(recordMap);
+  const postSummaries = NotionAdapter.getPostSummaries(recordMap);
 
   return (
     <>
-      {pageIds?.map((id) => (
+      {postSummaries?.map(({ id }) => (
         <Link key={id} href={`/${id}`}>
           go to {id}
         </Link>

--- a/src/entity/post/type.ts
+++ b/src/entity/post/type.ts
@@ -1,0 +1,10 @@
+export type PostStatus = 'writing' | 'private' | 'public';
+
+export type PostSummary = {
+  id: string;
+  title: string;
+  category: string;
+  status: PostStatus;
+  written: Date;
+  tag?: string[];
+};

--- a/src/infrastructure/notion/adapter/index.ts
+++ b/src/infrastructure/notion/adapter/index.ts
@@ -1,11 +1,63 @@
 import { ExtendedRecordMap } from 'notion-types';
 
+import { PostSummary } from '@/entity/post/type';
+
 class NotionAdapter {
-  static getPageIds = (recordMap: ExtendedRecordMap) => {
+  private static getPostIds = (recordMap: ExtendedRecordMap) => {
     const collectionQuery = Object.values(recordMap.collection_query)[0];
     const collectionQueryValue = Object.values(collectionQuery)[0]['collection_group_results'];
 
     return collectionQueryValue?.blockIds;
+  };
+
+  private static getPostSchema = (recordMap: ExtendedRecordMap) => {
+    return Object.values(recordMap.collection)[0].value.schema;
+  };
+
+  /**
+   * post의 정보를 반환합니다.
+   */
+  static getPostSummaries = (recordMap: ExtendedRecordMap): Array<PostSummary> => {
+    const block = recordMap.block;
+    const postIds = this.getPostIds(recordMap);
+
+    if (!postIds?.length) return [];
+
+    const schema = this.getPostSchema(recordMap);
+
+    return postIds.map((postId) => {
+      const postProperties = block[postId].value.properties as { [key in string]: unknown[] };
+      const summary = {
+        id: postId,
+      } as PostSummary;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Object.entries(postProperties).map(([key, value]: [string, any]) => {
+        const name = schema[key]?.name as keyof PostSummary;
+        if (!name) return;
+
+        switch (name) {
+          case 'title':
+          case 'category':
+            summary[name] = value[0][0] as PostSummary[typeof name];
+            break;
+          case 'status':
+            summary[name] = value[0][0] as PostSummary[typeof name];
+            break;
+          case 'tag': {
+            const tags = value[0][0].split(',') as PostSummary[typeof name];
+            summary[name] = tags;
+            break;
+          }
+          case 'written': {
+            const date = value[0][1][0][1].start_date as PostSummary[typeof name];
+            summary[name] = new Date(date);
+            break;
+          }
+        }
+      });
+      return summary;
+    });
   };
 }
 


### PR DESCRIPTION
## 👀 변경된 부분
- 페이지의 제목, 카테고리, 태그, 작성일, 상태를 구하는 메서드 `getPostSummaries` 를 추가합니다. 
- 메인 페이지에서 포스트를 알아볼 수 있도록 임시 카드를 추가합니다.

## 🖼️ 이미지
<img width="745" alt="image" src="https://github.com/user-attachments/assets/5e6914e9-b4c3-4249-aaa0-a0683db1e194" />


## 📚 참고 자료
