### PR TITLE
post header 추가

### DIFF
--- a/src/app/feature/post/index.ts
+++ b/src/app/feature/post/index.ts
@@ -1,0 +1,9 @@
+class PostFeature {
+  static getFormattedWrittenDate = (written: Date) => {
+    const year = written.getFullYear();
+    const month = written.getMonth() + 1;
+    return `${year}.${month.toString().padStart(2, '0')}`;
+  };
+}
+
+export default PostFeature;

--- a/src/app/posts/[slug]/_components/PostHeader.css.ts
+++ b/src/app/posts/[slug]/_components/PostHeader.css.ts
@@ -1,0 +1,34 @@
+import { style } from '@vanilla-extract/css';
+
+import { media } from '@/components/media.css';
+
+export const header = style({
+  margin: '40px auto',
+});
+
+export const postMetaWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  columnGap: '8px',
+  marginBottom: '16px',
+});
+
+export const written = style({
+  fontSize: '14px',
+  color: '#999999',
+});
+
+export const title = style([
+  {
+    fontSize: '24px',
+    fontWeight: 700,
+    lineHeight: 1.3,
+    color: '#1a1a1a',
+  },
+  media.tablet({
+    fontSize: '28px',
+  }),
+  media.desktop({
+    fontSize: '36px',
+  }),
+]);

--- a/src/app/posts/[slug]/_components/PostHeader.tsx
+++ b/src/app/posts/[slug]/_components/PostHeader.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import PostFeature from '@/app/feature/post';
+import TextDivider from '@/components/Divider/TextDivider';
+import CategoryBadge from '@/components/PostCard/CategoryBadge';
+import { PostCategory } from '@/entity/post/type';
+
+import * as styles from './PostHeader.css';
+
+interface Props {
+  title: string;
+  category: PostCategory;
+  written: Date;
+}
+
+function PostHeader({ title, category, written }: Props) {
+  return (
+    <div className={styles.header}>
+      <div className={styles.postMetaWrapper}>
+        <CategoryBadge category={category} />
+        <TextDivider separator="•" color="#999999" />
+        <time className={styles.written}>{PostFeature.getFormattedWrittenDate(written)}</time>
+      </div>
+      <h1 className={styles.title}>{title}</h1>
+    </div>
+  );
+}
+
+export default PostHeader;

--- a/src/app/posts/[slug]/_components/Renderer.css.ts
+++ b/src/app/posts/[slug]/_components/Renderer.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+
+export const renderer = style({
+  margin: 0,
+  padding: 0,
+});

--- a/src/app/posts/[slug]/_components/Renderer.tsx
+++ b/src/app/posts/[slug]/_components/Renderer.tsx
@@ -9,6 +9,8 @@ import Link from 'next/link';
 import { ExtendedRecordMap } from 'notion-types';
 import { NotionRenderer } from 'react-notion-x';
 
+import * as styles from './Renderer.css';
+
 const Code = dynamic(() => import('./Blocks/Code'), { ssr: false });
 
 interface Props {
@@ -20,6 +22,7 @@ function Renderer({ recordMap }: Props) {
     <NotionRenderer
       recordMap={recordMap}
       components={{ Code, nextImage: Image, nextLink: Link, Collection: () => <></> }}
+      className={styles.renderer}
     />
   );
 }

--- a/src/app/posts/[slug]/page.css.ts
+++ b/src/app/posts/[slug]/page.css.ts
@@ -1,17 +1,12 @@
-import { globalStyle, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
-export const article = style({
-  margin: '80px 0',
-});
+import { media } from '@/components/media.css';
 
-globalStyle(`${article} > main`, {
-  padding: 0,
-  margin: 0,
-  width: '100%',
-});
-
-export const title = style({
-  marginBottom: 32,
-  fontSize: 32,
-  letterSpacing: -0.8,
-});
+export const article = style([
+  {
+    padding: '20px',
+  },
+  media.desktop({
+    padding: '20px 0',
+  }),
+]);

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { PostSummary } from '@/entity/post/type';
 import NotionAdapter from '@/infrastructure/notion/adapter';
 import { notion } from '@/infrastructure/notion/adapter/api';
 
+import PostHeader from './_components/PostHeader';
 import Renderer from './_components/Renderer';
 import * as styles from './page.css';
 
@@ -15,13 +16,17 @@ async function PostPage({ params }: { params: Promise<PostPageParams> }) {
   const { slug } = await params;
 
   const recordMap = await notion.getPageData(process.env.NEXT_PUBLIC_NOTION_DATABASE_ID as string);
-  const pageId = NotionAdapter.getPageIdBySlug(recordMap, slug);
-  const result = await notion.getPageData(pageId);
-  const title = NotionAdapter.getPageTitle(result);
+  const postSummary = NotionAdapter.getPostSummaryBySlug(recordMap, slug);
+
+  const result = await notion.getPageData(postSummary.id);
 
   return (
     <article className={styles.article}>
-      <h1 className={styles.title}>{title}</h1>
+      <PostHeader
+        title={postSummary.title}
+        category={postSummary.category}
+        written={postSummary.written}
+      />
       <Renderer recordMap={result} />
     </article>
   );

--- a/src/components/Divider/TextDivider.tsx
+++ b/src/components/Divider/TextDivider.tsx
@@ -8,9 +8,10 @@ interface Props {
   color?: string;
   gap?: number;
   size?: number;
+  separator?: '|' | '•';
 }
 
-function TextDivider({ color, gap = 0, size }: Props) {
+function TextDivider({ separator = '|', color, gap = 0, size }: Props) {
   return (
     <span
       className={styles.textDivider}
@@ -22,7 +23,7 @@ function TextDivider({ color, gap = 0, size }: Props) {
         }),
       }}
     >
-      |
+      {separator}
     </span>
   );
 }

--- a/src/components/PostCard/index.tsx
+++ b/src/components/PostCard/index.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
 
+import PostFeature from '@/app/feature/post';
 import { PostSummary } from '@/entity/post/type';
 
 import CategoryBadge from './CategoryBadge';
 import CategoryIcon from './CategoryIcon';
 import * as styles from './index.css';
 import HashTag from '../HashTag';
-
-const getFormattedWrittenDate = (date: Date) => {
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  return `${year}.${month.toString().padStart(2, '0')}`;
-};
 
 interface Props {
   title: PostSummary['title'];
@@ -26,7 +21,7 @@ function PostCard({ title, description, written, category, tag }: Props) {
     <article className={styles.postCard}>
       <div className={styles.header}>
         <CategoryIcon category={category} />
-        <time className={styles.written}>{getFormattedWrittenDate(written)}</time>
+        <time className={styles.written}>{PostFeature.getFormattedWrittenDate(written)}</time>
       </div>
       <h2 className={styles.title}>{title}</h2>
       <p className={styles.description}>{description}</p>

--- a/src/infrastructure/notion/adapter/index.ts
+++ b/src/infrastructure/notion/adapter/index.ts
@@ -1,4 +1,4 @@
-import { Decoration, ExtendedRecordMap } from 'notion-types';
+import { ExtendedRecordMap } from 'notion-types';
 
 import { PostCategory, PostSummary } from '@/entity/post/type';
 
@@ -65,16 +65,6 @@ class NotionAdapter {
     });
   };
 
-  /**
-   * page id를 통해 page의 slug를 반환합니다.
-   */
-  static getPageIdBySlug = (recordMap: ExtendedRecordMap, slug: PostSummary['slug']) => {
-    const postSummaries = this.getPostSummaries(recordMap);
-    const currentPost = postSummaries.find((post) => post.slug === slug);
-
-    return currentPost?.id ?? '';
-  };
-
   static getCategoryList = (recordMap: ExtendedRecordMap): PostCategory[] => {
     const schema = this.getPostSchema(recordMap);
 
@@ -85,21 +75,21 @@ class NotionAdapter {
   };
 
   /**
-   * 글 제목을 반환합니다.
+   * page slug를 통해 post의 정보를 반환합니다.
    */
-  static getPageTitle(recordMap: ExtendedRecordMap) {
-    const pageInfoBlock = Object.values(recordMap.block)[0]?.value;
-    const titleBlock = pageInfoBlock.properties?.title;
+  static getPostSummaryBySlug = (
+    recordMap: ExtendedRecordMap,
+    slug: PostSummary['slug'],
+  ): PostSummary => {
+    const postSummaries = this.getPostSummaries(recordMap);
+    const matchedPostSummary = postSummaries.find((post) => post.slug === slug);
 
-    if (titleBlock && Array.isArray(titleBlock)) {
-      return (titleBlock as Decoration[])?.reduce(
-        (prev, current) => prev + (current[0] !== '⁍' && current[0] !== '‣' ? current[0] : ''),
-        '',
-      );
+    if (!matchedPostSummary) {
+      throw new Error(`${slug} 페이지 정보를 찾을 수 없음`);
     }
 
-    return '';
-  }
+    return matchedPostSummary;
+  };
 }
 
 export default NotionAdapter;


### PR DESCRIPTION
## 👀 변경된 부분
- `post/[slug]` 페이지에 post header 컴포넌트 추가
- `NotionAdapter`에서 post의 단편 정보를 가져오는 메서드(`getPageTitle`, `getPageIdBySlug`) 삭제 및 post summary를 가져오는 메서드(`getPostSummaryBySlug`)로 대체 
- written formatter(`getFormattedWrittenDate`) post feature에 추가
- post renderer margin, padding 삭제

## 🖼️ 이미지

| mobile | tablet | desktop |
| ------ | ------ | ------- |
|    ![iPhone 12 Pro-1753538837376](https://github.com/user-attachments/assets/22e59a86-eb37-468f-a5e8-ed0f71d0f0a6)    |    ![iPad-1753538840583](https://github.com/user-attachments/assets/7b7657f4-1d7d-44cf-bf58-9e6ff4935d46)    |     ![MacBook Pro-1753538842652](https://github.com/user-attachments/assets/f262411a-2bba-46be-8634-af538a57a55a)    |




## 📚 참고 자료
