### PR TITLE
post 스타일링 및 media query 함수 수정

### DIFF
--- a/src/app/posts/[slug]/_components/PostHeader.css.ts
+++ b/src/app/posts/[slug]/_components/PostHeader.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 
-import { media } from '@/components/media.css';
+import { responsiveStyle } from '@/components/media.css';
 
 export const header = style({
   margin: '40px auto',
@@ -25,10 +25,10 @@ export const title = style([
     lineHeight: 1.3,
     color: '#1a1a1a',
   },
-  media.tablet({
-    fontSize: '28px',
-  }),
-  media.desktop({
-    fontSize: '36px',
+  responsiveStyle({
+    tablet: { fontSize: '28px' },
+    desktop: {
+      fontSize: '36px',
+    },
   }),
 ]);

--- a/src/app/posts/[slug]/_components/PostHeader.css.ts
+++ b/src/app/posts/[slug]/_components/PostHeader.css.ts
@@ -3,7 +3,7 @@ import { style } from '@vanilla-extract/css';
 import { responsiveStyle } from '@/components/media.css';
 
 export const header = style({
-  margin: '40px auto',
+  margin: '40px auto 20px',
 });
 
 export const postMetaWrapper = style({

--- a/src/app/posts/[slug]/_components/Renderer.css.ts
+++ b/src/app/posts/[slug]/_components/Renderer.css.ts
@@ -1,6 +1,41 @@
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { responsiveStyle } from '@/components/media.css';
 
 export const renderer = style({
   margin: 0,
   padding: 0,
+});
+
+globalStyle(`${renderer} h2`, {
+  margin: '20px 0',
+
+  fontSize: '20px',
+  fontWeight: 600,
+  color: '#1a1a1a',
+  lineHeight: 1.4,
+
+  ...responsiveStyle({
+    tablet: { fontSize: '24px' },
+    desktop: { fontSize: '28px' },
+  }),
+});
+
+globalStyle(`${renderer} h3`, {
+  margin: '16px 0',
+
+  fontSize: '18px',
+  fontWeight: 600,
+  color: '#1a1a1a',
+  lineHeight: 1.4,
+
+  ...responsiveStyle({
+    tablet: { fontSize: '20px' },
+    desktop: { fontSize: '22px' },
+  }),
+});
+
+globalStyle(`${renderer} .notion-inline-code`, {
+  backgroundColor: '#f8f9fa',
+  color: '#1a1a1a',
 });

--- a/src/app/posts/[slug]/page.css.ts
+++ b/src/app/posts/[slug]/page.css.ts
@@ -1,12 +1,14 @@
 import { style } from '@vanilla-extract/css';
 
-import { media } from '@/components/media.css';
+import { responsiveStyle } from '@/components/media.css';
 
 export const article = style([
   {
     padding: '20px',
   },
-  media.desktop({
-    padding: '20px 0',
+  responsiveStyle({
+    desktop: {
+      padding: '20px 0',
+    },
   }),
 ]);

--- a/src/components/Badge/index.css.ts
+++ b/src/components/Badge/index.css.ts
@@ -1,6 +1,6 @@
 import { createThemeContract, style } from '@vanilla-extract/css';
 
-import { media } from '../media.css';
+import { responsiveStyle } from '../media.css';
 
 export const badgeVars = createThemeContract({
   color: '',
@@ -11,17 +11,19 @@ export const badgeVars = createThemeContract({
 export const badge = style([
   {
     padding: '3px 10px',
-    borderRadius: 10,
-    fontSize: 12,
+    borderRadius: '10px',
+    fontSize: '12px',
     fontWeight: 500,
     whiteSpace: 'nowrap',
     border: `1px solid ${badgeVars.borderColor}`,
     backgroundColor: badgeVars.backgroundColor,
     color: badgeVars.color,
   },
-  media.tablet({
-    padding: '4px 12px',
-    borderRadius: 12,
-    fontSize: 14,
+  responsiveStyle({
+    tablet: {
+      padding: '4px 12px',
+      borderRadius: '12px',
+      fontSize: '14px',
+    },
   }),
 ]);

--- a/src/components/HashTag/index.css.ts
+++ b/src/components/HashTag/index.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 
-import { media } from '../media.css';
+import { responsiveStyle } from '../media.css';
 
 export const hashTag = style([
   {
@@ -12,9 +12,11 @@ export const hashTag = style([
     color: '#666666',
     whiteSpace: 'nowrap',
   },
-  media.tablet({
-    padding: '3px 6px',
-    borderRadius: '4px',
-    fontSize: '12px',
+  responsiveStyle({
+    tablet: {
+      padding: '3px 6px',
+      borderRadius: '4px',
+      fontSize: '12px',
+    },
   }),
 ]);

--- a/src/components/Header/index.css.ts
+++ b/src/components/Header/index.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 
-import { media } from '../media.css';
+import { responsiveStyle } from '../media.css';
 
 export const header = style({
   width: '100%',
@@ -24,11 +24,13 @@ export const container = style([
     margin: '0 auto',
     padding: '0 16px',
   },
-  media.tablet({
-    flexDirection: 'row',
-    alignItems: 'center',
+  responsiveStyle({
+    tablet: {
+      flexDirection: 'row',
+      alignItems: 'center',
 
-    padding: '0 20px',
+      padding: '0 20px',
+    },
   }),
 ]);
 

--- a/src/components/PostCard/CategoryIcon.css.ts
+++ b/src/components/PostCard/CategoryIcon.css.ts
@@ -2,7 +2,7 @@ import { style, styleVariants } from '@vanilla-extract/css';
 
 import { PostCategory } from '@/entity/post/type';
 
-import { media } from '../media.css';
+import { responsiveStyle } from '../media.css';
 
 const base = style([
   {
@@ -16,15 +16,9 @@ const base = style([
     height: 36,
     fontSize: 18,
   },
-  media.tablet({
-    width: 40,
-    height: 40,
-    fontSize: 20,
-  }),
-  media.desktop({
-    width: 44,
-    height: 44,
-    fontSize: 22,
+  responsiveStyle({
+    tablet: { width: 40, height: 40, fontSize: 20 },
+    desktop: { width: 44, height: 44, fontSize: 22 },
   }),
 ]);
 

--- a/src/components/PostCard/index.css.ts
+++ b/src/components/PostCard/index.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 
-import { media } from '../media.css';
+import { responsiveStyle } from '../media.css';
 
 export const postCard = style([
   {
@@ -8,11 +8,9 @@ export const postCard = style([
     borderRadius: 12,
     padding: 20,
   },
-  media.tablet({
-    padding: 24,
-  }),
-  media.desktop({
-    padding: 32,
+  responsiveStyle({
+    tablet: { padding: 24 },
+    desktop: { padding: 32 },
   }),
 ]);
 
@@ -23,9 +21,8 @@ export const header = style([
     columnGap: 12,
     marginBottom: 12,
   },
-  media.tablet({
-    columnGap: 16,
-    marginBottom: 16,
+  responsiveStyle({
+    tablet: { columnGap: 16, marginBottom: 16 },
   }),
 ]);
 
@@ -44,12 +41,9 @@ export const title = style([
     color: '#1a1a1a',
     wordBreak: 'keep-all',
   },
-  media.tablet({
-    marginBottom: 12,
-    fontSize: 20,
-  }),
-  media.desktop({
-    fontSize: 22,
+  responsiveStyle({
+    tablet: { marginBottom: 12, fontSize: 20 },
+    desktop: { fontSize: 22 },
   }),
 ]);
 
@@ -59,9 +53,11 @@ export const description = style([
     lineHeight: 1.4,
     color: '#666666',
   },
-  media.tablet({
-    fontSize: 16,
-    lineHeight: 1.6,
+  responsiveStyle({
+    tablet: {
+      fontSize: 16,
+      lineHeight: 1.6,
+    },
   }),
 ]);
 

--- a/src/components/Tab/TabButton.css.ts
+++ b/src/components/Tab/TabButton.css.ts
@@ -1,6 +1,6 @@
 import { ComplexStyleRule, style, styleVariants } from '@vanilla-extract/css';
 
-import { media } from '../media.css';
+import { responsiveStyle } from '../media.css';
 
 const base = style([
   {
@@ -11,8 +11,8 @@ const base = style([
     fontSize: '12px',
     cursor: 'pointer',
   },
-  media.tablet({
-    fontSize: '14px',
+  responsiveStyle({
+    tablet: { fontSize: '14px' },
   }),
 ]);
 

--- a/src/components/Tab/index.css.ts
+++ b/src/components/Tab/index.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 
-import { media } from '../media.css';
+import { responsiveStyle } from '../media.css';
 
 export const tabList = style([
   {
@@ -11,12 +11,8 @@ export const tabList = style([
     flexWrap: 'wrap',
     padding: '14px 0',
   },
-  media.tablet({
-    columnGap: 24,
-    padding: '16px 0',
-  }),
-  media.desktop({
-    columnGap: 32,
-    padding: '20px 0',
+  responsiveStyle({
+    tablet: { columnGap: 24, padding: '16px 0' },
+    desktop: { columnGap: 32, padding: '20px 0' },
   }),
 ]);

--- a/src/components/media.css.ts
+++ b/src/components/media.css.ts
@@ -1,16 +1,14 @@
-import { style, StyleRule } from '@vanilla-extract/css';
+import { StyleRule } from '@vanilla-extract/css';
 
-export const media = {
-  tablet: (styles: StyleRule) =>
-    style({
-      '@media': {
-        '(min-width: 481px)': { ...styles },
-      },
-    }),
-  desktop: (styles: StyleRule) =>
-    style({
-      '@media': {
-        '(min-width: 769px)': { ...styles },
-      },
-    }),
-};
+export const responsiveStyle = ({
+  tablet,
+  desktop,
+}: {
+  tablet?: StyleRule;
+  desktop?: StyleRule;
+}) => ({
+  '@media': {
+    ...(tablet && { '(min-width: 481px)': tablet }),
+    ...(desktop && { '(min-width: 769px)': desktop }),
+  },
+});


### PR DESCRIPTION
## 👀 변경된 부분
- media query 적용 함수 수정
   - 기존: media query 별 style 함수로 적용
   - 변경: https://vanilla-extract.style/documentation/api/style/#style-merging 
   - 변경 사유: 기존 방법으로는 globalStyle에서 media query 적용 불가
- post h2, h3, inline-code block 스타일링 

## 🖼️ 이미지

| mobile | tablet | desktop |
| ------ | ------ | ------- |
|   ![iPhone 12 Pro-1753601719539](https://github.com/user-attachments/assets/af257805-74c7-4d5c-84ad-0904c81d12f7)     |     ![iPad-1753601729420](https://github.com/user-attachments/assets/7f9dffb1-cd65-4a0a-9240-18c40b5a46d0)   |     ![MacBook Pro-1753601723683](https://github.com/user-attachments/assets/0f4ddbc8-c07f-43a8-b099-1a28b15bfef8)    |

## 📚 참고 자료




