### PR TITLE
히트맵에 예정 경기 추가

### DIFF
--- a/src/app/baseball/page.tsx
+++ b/src/app/baseball/page.tsx
@@ -1,5 +1,6 @@
 import { BaseballAdapter } from '@/feature/baseball';
 import { BaseballConfig } from '@/shared/config';
+import { toLocalDateStr } from '@/shared/lib/date';
 import { GameRecord, styles } from '@/views/baseball';
 
 export const revalidate = 3600;
@@ -11,12 +12,15 @@ export default async function BaseballPage() {
   const heatmapStart = new Date(today);
   heatmapStart.setDate(heatmapStart.getDate() - BaseballConfig.heatmapWeeks * 7);
 
-  const todayStr = today.toISOString().slice(0, 10);
-  const heatmapStartStr = heatmapStart.toISOString().slice(0, 10);
+  const weekEnd = new Date(today);
+  weekEnd.setDate(today.getDate() + ((7 - today.getDay()) % 7));
+
+  const heatmapStartStr = toLocalDateStr(heatmapStart);
+  const weekEndStr = toLocalDateStr(weekEnd);
 
   const [season, heatmapGames] = await Promise.all([
     BaseballAdapter.getLatestSeason(),
-    BaseballAdapter.getGamesByDateRange(heatmapStartStr, todayStr),
+    BaseballAdapter.getGamesByDateRange(heatmapStartStr, weekEndStr),
   ]);
 
   const games = await BaseballAdapter.getGames(season);

--- a/src/feature/baseball/api/adapter.ts
+++ b/src/feature/baseball/api/adapter.ts
@@ -41,8 +41,6 @@ class BaseballAdapter {
       .eq('game_id_code', BaseballConfig.teamCode)
       .single();
 
-    console.log(data);
-
     if (error || !data) {
       throw new Error(`Team not found for code: ${BaseballConfig.teamCode}`);
     }

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -1,0 +1,6 @@
+export const toLocalDateStr = (date: Date): string => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+};

--- a/src/views/baseball/ui/GameRecord.css.ts
+++ b/src/views/baseball/ui/GameRecord.css.ts
@@ -100,3 +100,20 @@ export const statSeparator = style({
   marginBottom: '2px',
   flexShrink: 0,
 });
+
+export const heatmapSection = style({
+  paddingTop: '24px',
+  paddingBottom: '28px',
+});
+
+export const heatmapHeader = style({
+  marginBottom: '14px',
+});
+
+export const heatmapTitle = style({
+  fontFamily: vars.font.mono,
+  fontSize: '10px',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: vars.color.text.muted,
+});

--- a/src/views/baseball/ui/GameRecord.tsx
+++ b/src/views/baseball/ui/GameRecord.tsx
@@ -62,7 +62,13 @@ function GameRecord({ games, heatmapGames, season }: Props) {
         <StatGroup stats={regularStats} />
       </div>
 
-      <Heatmap games={heatmapGames} />
+      <div className={styles.heatmapSection}>
+        <div className={styles.heatmapHeader}>
+          <span className={styles.heatmapTitle}>경기 결과</span>
+        </div>
+
+        <Heatmap games={heatmapGames} />
+      </div>
     </section>
   );
 }

--- a/src/views/baseball/ui/Heatmap/DayCell.css.ts
+++ b/src/views/baseball/ui/Heatmap/DayCell.css.ts
@@ -1,0 +1,73 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { CELL_COLORS } from './styles';
+
+/**
+ * ======== CELL ========
+ */
+
+const cellBase = style({
+  width: '13px',
+  height: '13px',
+  borderRadius: '3px',
+  flexShrink: 0,
+  cursor: 'default',
+  position: 'relative',
+  transition: 'filter .12s, transform .12s',
+});
+
+const interactiveCell = {
+  cursor: 'pointer',
+  selectors: {
+    '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
+  },
+} as const;
+
+export const cellVariants = styleVariants({
+  'big-win': [cellBase, { background: CELL_COLORS['big-win'], ...interactiveCell }],
+  win: [cellBase, { background: CELL_COLORS.win, ...interactiveCell }],
+  draw: [cellBase, { background: CELL_COLORS.draw, ...interactiveCell }],
+  lose: [cellBase, { background: CELL_COLORS.lose, ...interactiveCell }],
+  'big-lose': [cellBase, { background: CELL_COLORS['big-lose'], ...interactiveCell }],
+  canceled: [cellBase, { background: CELL_COLORS.canceled, opacity: 0.5, ...interactiveCell }],
+  scheduled: [cellBase, { background: CELL_COLORS.scheduled, ...interactiveCell }],
+  empty: [cellBase, { background: CELL_COLORS.empty }],
+});
+
+/**
+ * ======== DOUBLE HEADER CELL ========
+ */
+
+export const cellDoubleWrapper = style({
+  width: '13px',
+  height: '13px',
+  borderRadius: '3px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1px',
+  overflow: 'hidden',
+  flexShrink: 0,
+  cursor: 'pointer',
+  position: 'relative',
+  transition: 'filter .12s, transform .12s',
+  selectors: {
+    '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
+  },
+});
+
+const cellHalfBase = style({
+  width: '100%',
+  flex: 1,
+  minHeight: 0,
+});
+
+export const cellHalfVariants = styleVariants({
+  'big-win': [cellHalfBase, { background: CELL_COLORS['big-win'] }],
+  win: [cellHalfBase, { background: CELL_COLORS.win }],
+  draw: [cellHalfBase, { background: CELL_COLORS.draw }],
+  lose: [cellHalfBase, { background: CELL_COLORS.lose }],
+  'big-lose': [cellHalfBase, { background: CELL_COLORS['big-lose'] }],
+  canceled: [cellHalfBase, { background: CELL_COLORS.canceled, opacity: 0.5 }],
+  scheduled: [cellHalfBase, { background: CELL_COLORS.scheduled }],
+  empty: [cellHalfBase, { background: CELL_COLORS.empty }],
+});

--- a/src/views/baseball/ui/Heatmap/DayCell.tsx
+++ b/src/views/baseball/ui/Heatmap/DayCell.tsx
@@ -1,16 +1,8 @@
 'use client';
 
-import { Game } from '@/entity/baseball';
-
 import * as styles from './index.css';
-import { CellVariant, HeatmapDay } from './types';
-
-export const getCellVariant = (game: Game): CellVariant => {
-  if (game.status === 'canceled') return 'canceled';
-  if (game.status === 'scheduled') return 'scheduled';
-  if (game.result === null) return 'empty';
-  return game.result;
-};
+import { HeatmapDay } from './types';
+import { getCellVariant } from './utils';
 
 interface Props {
   day: HeatmapDay;
@@ -20,13 +12,9 @@ interface Props {
 }
 
 function DayCell({ day, onEnter, onMove, onLeave }: Props) {
-  const { games, isFuture } = day;
+  const { games } = day;
 
-  if (isFuture) {
-    return <div className={styles.cellVariants['future-empty']} />;
-  }
-
-  // 더블헤더 (같은 날 2경기)
+  // 더블헤더
   if (games.length >= 2) {
     const [g1, g2] = games;
     const v1 = getCellVariant(g1);

--- a/src/views/baseball/ui/Heatmap/DayCell.tsx
+++ b/src/views/baseball/ui/Heatmap/DayCell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as styles from './index.css';
+import * as styles from './DayCell.css';
 import { HeatmapDay } from './types';
 import { getCellVariant } from './utils';
 

--- a/src/views/baseball/ui/Heatmap/DayLabel.css.ts
+++ b/src/views/baseball/ui/Heatmap/DayLabel.css.ts
@@ -1,0 +1,31 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/shared/styles';
+
+export const dayLabels = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '3px',
+  width: '14px',
+  flexShrink: 0,
+});
+
+export const monthLabelSpacer = style({
+  height: '16px',
+  flexShrink: 0,
+});
+
+export const dayLabelText = style({
+  fontFamily: vars.font.mono,
+  fontSize: '9px',
+  color: vars.color.text.muted,
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  lineHeight: 1,
+});
+
+export const dayLabelEmpty = style({
+  flex: 1,
+});

--- a/src/views/baseball/ui/Heatmap/DayLabel.tsx
+++ b/src/views/baseball/ui/Heatmap/DayLabel.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import * as styles from './DayLabel.css';
+
+const DAY_LABEL_MAP: Record<number, string> = {
+  1: '화',
+  4: '금',
+  6: '일',
+};
+
+const dayLabelItems = Array.from({ length: 7 }, (_, i) => ({
+  dow: i,
+  label: DAY_LABEL_MAP[i] ?? null,
+}));
+
+function DayLabel() {
+  return (
+    <div className={styles.dayLabels}>
+      <div className={styles.monthLabelSpacer} />
+      {dayLabelItems.map(({ dow, label }) =>
+        label ? (
+          <div key={dow} className={styles.dayLabelText}>
+            {label}
+          </div>
+        ) : (
+          <div key={dow} className={styles.dayLabelEmpty} />
+        ),
+      )}
+    </div>
+  );
+}
+
+export default DayLabel;

--- a/src/views/baseball/ui/Heatmap/Legend.css.ts
+++ b/src/views/baseball/ui/Heatmap/Legend.css.ts
@@ -1,0 +1,70 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { space, vars } from '@/shared/styles';
+
+import { CELL_COLORS } from './styles';
+
+export const legendWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: space[8],
+  marginTop: space[12],
+  paddingLeft: '18px',
+});
+
+export const legendGroup = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+});
+
+export const legendSep = style({
+  width: '1px',
+  height: '10px',
+  background: vars.color.border,
+  marginLeft: '4px',
+  marginRight: '4px',
+});
+
+export const legendText = style({
+  fontFamily: vars.font.mono,
+  fontSize: '9px',
+  color: vars.color.text.muted,
+  letterSpacing: '0.04em',
+});
+
+const legendCellBase = style({
+  width: '13px',
+  height: '13px',
+  borderRadius: '3px',
+  position: 'relative',
+  flexShrink: 0,
+});
+
+export const legendCellVariants = styleVariants({
+  'big-lose': [legendCellBase, { background: CELL_COLORS['big-lose'] }],
+  lose: [legendCellBase, { background: CELL_COLORS.lose }],
+  draw: [legendCellBase, { background: CELL_COLORS.draw }],
+  win: [legendCellBase, { background: CELL_COLORS.win }],
+  'big-win': [legendCellBase, { background: CELL_COLORS['big-win'] }],
+  empty: [legendCellBase, { background: CELL_COLORS.empty }],
+  scheduled: [legendCellBase, { background: CELL_COLORS.scheduled }],
+  visited: [
+    legendCellBase,
+    {
+      background: CELL_COLORS.win,
+      selectors: {
+        '&::after': {
+          content: '""',
+          position: 'absolute',
+          bottom: '2px',
+          right: '2px',
+          width: '3px',
+          height: '3px',
+          borderRadius: '50%',
+          background: 'rgba(0,0,0,0.5)',
+        },
+      },
+    },
+  ],
+});

--- a/src/views/baseball/ui/Heatmap/Legend.tsx
+++ b/src/views/baseball/ui/Heatmap/Legend.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import * as styles from './Legend.css';
+import { CellVariant } from './types';
+
+const GAME_RESULT_LIST = [
+  'big-lose',
+  'lose',
+  'draw',
+  'win',
+  'big-win',
+] as const satisfies CellVariant[];
+
+function Legend() {
+  return (
+    <div className={styles.legendWrapper}>
+      <div className={styles.legendGroup}>
+        <span className={styles.legendText}>패</span>
+        {GAME_RESULT_LIST.map((v) => (
+          <div key={v} className={styles.legendCellVariants[v]} />
+        ))}
+        <span className={styles.legendText}>승</span>
+      </div>
+
+      <div className={styles.legendSep} />
+
+      <div className={styles.legendGroup}>
+        <div className={styles.legendCellVariants.empty} />
+        <span className={styles.legendText}>없음</span>
+      </div>
+
+      <div className={styles.legendGroup}>
+        <div className={styles.legendCellVariants.scheduled} />
+        <span className={styles.legendText}>예정</span>
+      </div>
+
+      <div className={styles.legendSep} />
+
+      <div className={styles.legendGroup}>
+        <div className={styles.legendCellVariants.visited} />
+        <span className={styles.legendText}>직관</span>
+      </div>
+    </div>
+  );
+}
+
+export default Legend;

--- a/src/views/baseball/ui/Heatmap/MonthLabel.css.ts
+++ b/src/views/baseball/ui/Heatmap/MonthLabel.css.ts
@@ -1,0 +1,20 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/shared/styles';
+
+export const monthLabelsRow = style({
+  display: 'flex',
+  flexDirection: 'row',
+  height: '16px',
+  flexShrink: 0,
+});
+
+export const monthLabel = style({
+  fontFamily: vars.font.mono,
+  fontSize: '9px',
+  color: vars.color.text.muted,
+  lineHeight: '16px',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  flexShrink: 0,
+});

--- a/src/views/baseball/ui/Heatmap/MonthLabel.tsx
+++ b/src/views/baseball/ui/Heatmap/MonthLabel.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import * as styles from './MonthLabel.css';
+import { HeatmapGrid } from './types';
+
+interface Props {
+  monthLabels: HeatmapGrid['monthLabels'];
+}
+
+function MonthLabel({ monthLabels }: Props) {
+  return (
+    <div className={styles.monthLabelsRow}>
+      {monthLabels.map(({ label, width, startWeek }) => (
+        <span key={startWeek} className={styles.monthLabel} style={{ width }}>
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default MonthLabel;

--- a/src/views/baseball/ui/Heatmap/TooltipContent.css.ts
+++ b/src/views/baseball/ui/Heatmap/TooltipContent.css.ts
@@ -1,0 +1,41 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { vars } from '@/shared/styles';
+
+import { CELL_COLORS } from './styles';
+
+export const tooltipDate = style({
+  display: 'block',
+  fontFamily: vars.font.mono,
+  fontSize: '10px',
+  color: vars.color.text.muted,
+  marginBottom: '2px',
+});
+
+export const tooltipResultVariants = styleVariants(
+  {
+    'big-win': { color: CELL_COLORS.win },
+    win: { color: CELL_COLORS.win },
+    draw: { color: CELL_COLORS.draw },
+    lose: { color: CELL_COLORS.lose },
+    'big-lose': { color: CELL_COLORS.lose },
+    scheduled: { color: CELL_COLORS.scheduled },
+    canceled: { color: CELL_COLORS.canceled },
+  },
+  (variant) => ({ display: 'block', fontWeight: 700, ...variant }),
+);
+
+export const tooltipScore = style({
+  display: 'block',
+  color: '#ddd',
+});
+
+export const tooltipInfo = style({
+  display: 'block',
+  fontSize: '10px',
+  color: vars.color.text.muted,
+});
+
+export const tooltipGame = style({
+  display: 'block',
+});

--- a/src/views/baseball/ui/Heatmap/TooltipContent.tsx
+++ b/src/views/baseball/ui/Heatmap/TooltipContent.tsx
@@ -34,11 +34,12 @@ function TooltipContent({ day }: Props) {
       {games.map((game, i) => {
         const variant = getCellVariant(game);
         const isHome = game.isHome ? '홈' : '원정';
+        const opponentInfo = `vs ${game.opponent} · ${game.stadium ?? isHome}`;
 
         if (game.status === 'canceled') {
           return (
             <span key={i} className={styles.tooltipGame}>
-              취소 · vs {game.opponent}
+              취소 · {opponentInfo}
             </span>
           );
         }
@@ -46,7 +47,7 @@ function TooltipContent({ day }: Props) {
         if (game.status === 'scheduled') {
           return (
             <span key={i} className={styles.tooltipGame}>
-              예정 · vs {game.opponent} · {isHome}
+              예정 · {opponentInfo}
             </span>
           );
         }
@@ -66,9 +67,7 @@ function TooltipContent({ day }: Props) {
             <span className={styles.tooltipScore}>
               {myScore} : {opponentScore}
             </span>
-            <span className={styles.tooltipInfo}>
-              vs {game.opponent} · {isHome}
-            </span>
+            <span className={styles.tooltipInfo}>{opponentInfo}</span>
           </span>
         );
       })}

--- a/src/views/baseball/ui/Heatmap/TooltipContent.tsx
+++ b/src/views/baseball/ui/Heatmap/TooltipContent.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import { getCellVariant } from './DayCell';
 import * as styles from './index.css';
-import { HeatmapDay } from './types';
+import { GameInfo, HeatmapDay } from './types';
+import { getCellVariant, hasGameInfo } from './utils';
 
-const RESULT_LABEL: Record<string, string> = {
+const VARIANT_LABEL: Record<GameInfo, string> = {
   'big-win': '승',
   win: '승',
   draw: '무',
   lose: '패',
   'big-lose': '패',
+  canceled: '취소',
+  scheduled: '예정',
 };
 
 const formatDate = (dateStr: string): string => {
@@ -36,37 +38,22 @@ function TooltipContent({ day }: Props) {
         const isHome = game.isHome ? '홈' : '원정';
         const opponentInfo = `vs ${game.opponent} · ${game.stadium ?? isHome}`;
 
-        if (game.status === 'canceled') {
-          return (
-            <span key={i} className={styles.tooltipGame}>
-              취소 · {opponentInfo}
-            </span>
-          );
-        }
+        const gameInfo = hasGameInfo(variant) ? variant : null;
+        const label = gameInfo ? VARIANT_LABEL[gameInfo] : '';
+        const labelClass = gameInfo ? styles.tooltipResultVariants[gameInfo] : null;
 
-        if (game.status === 'scheduled') {
-          return (
-            <span key={i} className={styles.tooltipGame}>
-              예정 · {opponentInfo}
-            </span>
-          );
-        }
-
+        const isCompleted = game.status === 'completed';
         const myScore = game.isHome ? game.homeScore : game.awayScore;
         const opponentScore = game.isHome ? game.awayScore : game.homeScore;
-        const resultLabel = RESULT_LABEL[variant] ?? '';
-        const resultVariant = variant as keyof typeof styles.tooltipResultVariants;
-        const resultClass =
-          resultVariant in styles.tooltipResultVariants
-            ? styles.tooltipResultVariants[resultVariant]
-            : undefined;
 
         return (
           <span key={i}>
-            {resultClass && <span className={resultClass}>{resultLabel}</span>}
-            <span className={styles.tooltipScore}>
-              {myScore} : {opponentScore}
-            </span>
+            {labelClass && <span className={labelClass}>{label}</span>}
+            {isCompleted && (
+              <span className={styles.tooltipScore}>
+                {myScore} : {opponentScore}
+              </span>
+            )}
             <span className={styles.tooltipInfo}>{opponentInfo}</span>
           </span>
         );

--- a/src/views/baseball/ui/Heatmap/TooltipContent.tsx
+++ b/src/views/baseball/ui/Heatmap/TooltipContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as styles from './index.css';
+import * as styles from './TooltipContent.css';
 import { GameInfo, HeatmapDay } from './types';
 import { getCellVariant, hasGameInfo } from './utils';
 

--- a/src/views/baseball/ui/Heatmap/index.css.ts
+++ b/src/views/baseball/ui/Heatmap/index.css.ts
@@ -1,29 +1,10 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
-import { vars } from '@/shared/styles/contract.css';
-import { space } from '@/shared/styles/spacing';
+import { vars, space } from '@/shared/styles';
 
 /**
  * ======== LAYOUT ========
  */
-
-export const heatmapSection = style({
-  paddingTop: '24px',
-  paddingBottom: '28px',
-});
-
-export const heatmapHeader = style({
-  marginBottom: '14px',
-});
-
-export const heatmapTitle = style({
-  fontFamily: vars.font.mono,
-  fontSize: '10px',
-  letterSpacing: '0.1em',
-  textTransform: 'uppercase',
-  color: vars.color.text.muted,
-});
-
 export const heatmap = style({
   width: '100%',
   overflowX: 'auto',
@@ -47,38 +28,6 @@ export const gridWrapper = style({
 });
 
 /**
- * ======== DAY ========
- */
-
-export const dayLabels = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '3px',
-  width: '14px',
-  flexShrink: 0,
-});
-
-export const monthLabelSpacer = style({
-  height: '16px',
-  flexShrink: 0,
-});
-
-export const dayLabelText = style({
-  fontFamily: vars.font.mono,
-  fontSize: '9px',
-  color: vars.color.text.muted,
-  flex: 1,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'flex-end',
-  lineHeight: 1,
-});
-
-export const dayLabelEmpty = style({
-  flex: 1,
-});
-
-/**
  * ======== WEEKS ========
  */
 
@@ -86,23 +35,6 @@ export const weeksWrapper = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '3px',
-});
-
-export const monthLabelsRow = style({
-  display: 'flex',
-  flexDirection: 'row',
-  height: '16px',
-  flexShrink: 0,
-});
-
-export const monthLabel = style({
-  fontFamily: vars.font.mono,
-  fontSize: '9px',
-  color: vars.color.text.muted,
-  lineHeight: '16px',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  flexShrink: 0,
 });
 
 export const weeks = style({
@@ -116,91 +48,6 @@ export const week = style({
   flexDirection: 'column',
   gap: '3px',
   flexShrink: 0,
-});
-
-/**
- * ======== CELL COLORS ========
- */
-
-const CELL_COLORS = {
-  'big-win': '#FF6600',
-  win: '#FFAA77',
-  draw: '#e8d5b0',
-  lose: '#90B8D8',
-  'big-lose': '#5A8AB0',
-  canceled: '#E0E0E0',
-  scheduled: '#C8C8C8',
-  empty: '#EBEBEB',
-} as const;
-
-/**
- * ======== CELL ========
- */
-
-const cellBase = style({
-  width: '13px',
-  height: '13px',
-  borderRadius: '3px',
-  flexShrink: 0,
-  cursor: 'default',
-  position: 'relative',
-  transition: 'filter .12s, transform .12s',
-});
-
-const interactiveCell = {
-  cursor: 'pointer',
-  selectors: {
-    '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
-  },
-} as const;
-
-export const cellVariants = styleVariants({
-  'big-win': [cellBase, { background: CELL_COLORS['big-win'], ...interactiveCell }],
-  win: [cellBase, { background: CELL_COLORS.win, ...interactiveCell }],
-  draw: [cellBase, { background: CELL_COLORS.draw, ...interactiveCell }],
-  lose: [cellBase, { background: CELL_COLORS.lose, ...interactiveCell }],
-  'big-lose': [cellBase, { background: CELL_COLORS['big-lose'], ...interactiveCell }],
-  canceled: [cellBase, { background: CELL_COLORS.canceled, opacity: 0.5, ...interactiveCell }],
-  scheduled: [cellBase, { background: CELL_COLORS.scheduled, ...interactiveCell }],
-  empty: [cellBase, { background: CELL_COLORS.empty }],
-});
-
-/**
- * ======== DOUBLE HEADER CELL ========
- */
-
-export const cellDoubleWrapper = style({
-  width: '13px',
-  height: '13px',
-  borderRadius: '3px',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1px',
-  overflow: 'hidden',
-  flexShrink: 0,
-  cursor: 'pointer',
-  position: 'relative',
-  transition: 'filter .12s, transform .12s',
-  selectors: {
-    '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
-  },
-});
-
-const cellHalfBase = style({
-  width: '100%',
-  flex: 1,
-  minHeight: 0,
-});
-
-export const cellHalfVariants = styleVariants({
-  'big-win': [cellHalfBase, { background: CELL_COLORS['big-win'] }],
-  win: [cellHalfBase, { background: CELL_COLORS.win }],
-  draw: [cellHalfBase, { background: CELL_COLORS.draw }],
-  lose: [cellHalfBase, { background: CELL_COLORS.lose }],
-  'big-lose': [cellHalfBase, { background: CELL_COLORS['big-lose'] }],
-  canceled: [cellHalfBase, { background: CELL_COLORS.canceled, opacity: 0.5 }],
-  scheduled: [cellHalfBase, { background: CELL_COLORS.scheduled }],
-  empty: [cellHalfBase, { background: CELL_COLORS.empty }],
 });
 
 /**
@@ -223,109 +70,4 @@ export const floatingTooltip = style({
   borderRadius: '6px',
 
   pointerEvents: 'none',
-});
-
-export const tooltipDate = style({
-  display: 'block',
-  fontFamily: vars.font.mono,
-  fontSize: '10px',
-  color: vars.color.text.muted,
-  marginBottom: '2px',
-});
-
-export const tooltipResultVariants = styleVariants(
-  {
-    'big-win': { color: CELL_COLORS.win },
-    win: { color: CELL_COLORS.win },
-    draw: { color: CELL_COLORS.draw },
-    lose: { color: CELL_COLORS.lose },
-    'big-lose': { color: CELL_COLORS.lose },
-    scheduled: { color: CELL_COLORS.scheduled },
-    canceled: { color: CELL_COLORS.canceled },
-  },
-  (variant) => ({ display: 'block', fontWeight: 700, ...variant }),
-);
-
-export const tooltipScore = style({
-  display: 'block',
-  color: '#ddd',
-});
-
-export const tooltipInfo = style({
-  display: 'block',
-  fontSize: '10px',
-  color: vars.color.text.muted,
-});
-
-export const tooltipGame = style({
-  display: 'block',
-});
-
-/**
- * ======== LEGEND ========
- */
-
-export const legendWrapper = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: space[8],
-  marginTop: space[12],
-  paddingLeft: '18px',
-});
-
-export const legendGroup = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '4px',
-});
-
-export const legendSep = style({
-  width: '1px',
-  height: '10px',
-  background: vars.color.border,
-  marginLeft: '4px',
-  marginRight: '4px',
-});
-
-export const legendText = style({
-  fontFamily: vars.font.mono,
-  fontSize: '9px',
-  color: vars.color.text.muted,
-  letterSpacing: '0.04em',
-});
-
-const legendCellBase = style({
-  width: '13px',
-  height: '13px',
-  borderRadius: '3px',
-  position: 'relative',
-  flexShrink: 0,
-});
-
-export const legendCellVariants = styleVariants({
-  'big-lose': [legendCellBase, { background: CELL_COLORS['big-lose'] }],
-  lose: [legendCellBase, { background: CELL_COLORS.lose }],
-  draw: [legendCellBase, { background: CELL_COLORS.draw }],
-  win: [legendCellBase, { background: CELL_COLORS.win }],
-  'big-win': [legendCellBase, { background: CELL_COLORS['big-win'] }],
-  empty: [legendCellBase, { background: CELL_COLORS.empty }],
-  scheduled: [legendCellBase, { background: CELL_COLORS.scheduled }],
-  visited: [
-    legendCellBase,
-    {
-      background: CELL_COLORS.win,
-      selectors: {
-        '&::after': {
-          content: '""',
-          position: 'absolute',
-          bottom: '2px',
-          right: '2px',
-          width: '3px',
-          height: '3px',
-          borderRadius: '50%',
-          background: 'rgba(0,0,0,0.5)',
-        },
-      },
-    },
-  ],
 });

--- a/src/views/baseball/ui/Heatmap/index.css.ts
+++ b/src/views/baseball/ui/Heatmap/index.css.ts
@@ -119,6 +119,21 @@ export const week = style({
 });
 
 /**
+ * ======== CELL COLORS ========
+ */
+
+const CELL_COLORS = {
+  'big-win': '#FF6600',
+  win: '#FFAA77',
+  draw: '#e8d5b0',
+  lose: '#90B8D8',
+  'big-lose': '#5A8AB0',
+  canceled: '#E0E0E0',
+  scheduled: '#C8C8C8',
+  empty: '#EBEBEB',
+} as const;
+
+/**
  * ======== CELL ========
  */
 
@@ -132,79 +147,22 @@ const cellBase = style({
   transition: 'filter .12s, transform .12s',
 });
 
+const interactiveCell = {
+  cursor: 'pointer',
+  selectors: {
+    '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
+  },
+} as const;
+
 export const cellVariants = styleVariants({
-  'big-win': [
-    cellBase,
-    {
-      background: '#FF6600',
-      cursor: 'pointer',
-      selectors: {
-        '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
-      },
-    },
-  ],
-  win: [
-    cellBase,
-    {
-      background: '#FFAA77',
-      cursor: 'pointer',
-      selectors: {
-        '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
-      },
-    },
-  ],
-  draw: [
-    cellBase,
-    {
-      background: '#e8d5b0',
-      cursor: 'pointer',
-      selectors: {
-        '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
-      },
-    },
-  ],
-  lose: [
-    cellBase,
-    {
-      background: '#90B8D8',
-      cursor: 'pointer',
-      selectors: {
-        '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
-      },
-    },
-  ],
-  'big-lose': [
-    cellBase,
-    {
-      background: '#5A8AB0',
-      cursor: 'pointer',
-      selectors: {
-        '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
-      },
-    },
-  ],
-  canceled: [
-    cellBase,
-    {
-      background: '#E0E0E0',
-      opacity: 0.5,
-      cursor: 'pointer',
-      selectors: {
-        '&:hover': { filter: 'brightness(.82)', transform: 'scale(1.3)', zIndex: 10 },
-      },
-    },
-  ],
-  scheduled: [cellBase, { background: vars.color.border }],
-  empty: [cellBase, { background: '#E0E0E0' }],
-  'future-empty': [
-    cellBase,
-    {
-      background: 'transparent',
-      selectors: {
-        '&:hover': { filter: 'none', transform: 'none' },
-      },
-    },
-  ],
+  'big-win': [cellBase, { background: CELL_COLORS['big-win'], ...interactiveCell }],
+  win: [cellBase, { background: CELL_COLORS.win, ...interactiveCell }],
+  draw: [cellBase, { background: CELL_COLORS.draw, ...interactiveCell }],
+  lose: [cellBase, { background: CELL_COLORS.lose, ...interactiveCell }],
+  'big-lose': [cellBase, { background: CELL_COLORS['big-lose'], ...interactiveCell }],
+  canceled: [cellBase, { background: CELL_COLORS.canceled, opacity: 0.5, ...interactiveCell }],
+  scheduled: [cellBase, { background: CELL_COLORS.scheduled, ...interactiveCell }],
+  empty: [cellBase, { background: CELL_COLORS.empty }],
 });
 
 /**
@@ -235,14 +193,14 @@ const cellHalfBase = style({
 });
 
 export const cellHalfVariants = styleVariants({
-  'big-win': [cellHalfBase, { background: '#FF6600' }],
-  win: [cellHalfBase, { background: '#FFAA77' }],
-  draw: [cellHalfBase, { background: '#e8d5b0' }],
-  lose: [cellHalfBase, { background: '#90B8D8' }],
-  'big-lose': [cellHalfBase, { background: '#5A8AB0' }],
-  canceled: [cellHalfBase, { background: '#E0E0E0', opacity: 0.5 }],
-  scheduled: [cellHalfBase, { background: vars.color.border }],
-  empty: [cellHalfBase, { background: '#E0E0E0' }],
+  'big-win': [cellHalfBase, { background: CELL_COLORS['big-win'] }],
+  win: [cellHalfBase, { background: CELL_COLORS.win }],
+  draw: [cellHalfBase, { background: CELL_COLORS.draw }],
+  lose: [cellHalfBase, { background: CELL_COLORS.lose }],
+  'big-lose': [cellHalfBase, { background: CELL_COLORS['big-lose'] }],
+  canceled: [cellHalfBase, { background: CELL_COLORS.canceled, opacity: 0.5 }],
+  scheduled: [cellHalfBase, { background: CELL_COLORS.scheduled }],
+  empty: [cellHalfBase, { background: CELL_COLORS.empty }],
 });
 
 /**
@@ -275,13 +233,18 @@ export const tooltipDate = style({
   marginBottom: '2px',
 });
 
-export const tooltipResultVariants = styleVariants({
-  'big-win': { display: 'block', fontWeight: 700, color: '#FF8833' },
-  win: { display: 'block', fontWeight: 700, color: '#FFAA77' },
-  draw: { display: 'block', fontWeight: 700, color: '#b07020' },
-  lose: { display: 'block', fontWeight: 700, color: '#90B8D8' },
-  'big-lose': { display: 'block', fontWeight: 700, color: '#7aaac8' },
-});
+export const tooltipResultVariants = styleVariants(
+  {
+    'big-win': { color: CELL_COLORS.win },
+    win: { color: CELL_COLORS.win },
+    draw: { color: CELL_COLORS.draw },
+    lose: { color: CELL_COLORS.lose },
+    'big-lose': { color: CELL_COLORS.lose },
+    scheduled: { color: CELL_COLORS.scheduled },
+    canceled: { color: CELL_COLORS.canceled },
+  },
+  (variant) => ({ display: 'block', fontWeight: 700, ...variant }),
+);
 
 export const tooltipScore = style({
   display: 'block',
@@ -340,16 +303,17 @@ const legendCellBase = style({
 });
 
 export const legendCellVariants = styleVariants({
-  'big-lose': [legendCellBase, { background: '#5A8AB0' }],
-  lose: [legendCellBase, { background: '#90B8D8' }],
-  draw: [legendCellBase, { background: '#e8d5b0' }],
-  win: [legendCellBase, { background: '#FFAA77' }],
-  'big-win': [legendCellBase, { background: '#FF6600' }],
-  empty: [legendCellBase, { background: '#E0E0E0' }],
+  'big-lose': [legendCellBase, { background: CELL_COLORS['big-lose'] }],
+  lose: [legendCellBase, { background: CELL_COLORS.lose }],
+  draw: [legendCellBase, { background: CELL_COLORS.draw }],
+  win: [legendCellBase, { background: CELL_COLORS.win }],
+  'big-win': [legendCellBase, { background: CELL_COLORS['big-win'] }],
+  empty: [legendCellBase, { background: CELL_COLORS.empty }],
+  scheduled: [legendCellBase, { background: CELL_COLORS.scheduled }],
   visited: [
     legendCellBase,
     {
-      background: '#FFAA77',
+      background: CELL_COLORS.win,
       selectors: {
         '&::after': {
           content: '""',

--- a/src/views/baseball/ui/Heatmap/index.tsx
+++ b/src/views/baseball/ui/Heatmap/index.tsx
@@ -8,10 +8,13 @@ import { Game } from '@/entity/baseball';
 import { useMounted } from '@/shared/hooks';
 
 import DayCell from './DayCell';
+import DayLabel from './DayLabel';
 import * as styles from './index.css';
+import Legend from './Legend';
+import MonthLabel from './MonthLabel';
 import TooltipContent from './TooltipContent';
 import { HeatmapDay } from './types';
-import { buildHeatmapGrid, DAY_LABEL_MAP } from './utils';
+import { buildHeatmapGrid } from './utils';
 
 interface Props {
   games: Game[];
@@ -22,12 +25,6 @@ function Heatmap({ games }: Props) {
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
   const mounted = useMounted();
   const gridRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (gridRef.current) {
-      gridRef.current.scrollLeft = gridRef.current.scrollWidth;
-    }
-  }, []);
 
   const { weeks, monthLabels } = buildHeatmapGrid(games);
 
@@ -44,47 +41,21 @@ function Heatmap({ games }: Props) {
     setHoveredDay(null);
   };
 
-  const dayLabelItems = Array.from({ length: 7 }, (_, i) => ({
-    dow: i,
-    label: DAY_LABEL_MAP[i] ?? null,
-  }));
+  useEffect(() => {
+    if (gridRef.current) {
+      gridRef.current.scrollLeft = gridRef.current.scrollWidth;
+    }
+  }, []);
 
   return (
-    <div className={styles.heatmapSection}>
-      {/* 섹션 헤더 */}
-      <div className={styles.heatmapHeader}>
-        <span className={styles.heatmapTitle}>경기 결과</span>
-      </div>
-
-      {/* 히트맵 그리드 */}
+    <>
       <div className={styles.heatmap} ref={gridRef}>
         <div className={styles.gridWrapper}>
-          {/* 요일 레이블 컬럼 */}
-          <div className={styles.dayLabels}>
-            <div className={styles.monthLabelSpacer} />
-            {dayLabelItems.map(({ dow, label }) =>
-              label ? (
-                <div key={dow} className={styles.dayLabelText}>
-                  {label}
-                </div>
-              ) : (
-                <div key={dow} className={styles.dayLabelEmpty} />
-              ),
-            )}
-          </div>
+          <DayLabel />
 
-          {/* 월 레이블 + 주 그리드 */}
           <div className={styles.weeksWrapper}>
-            {/* 월 레이블 행 */}
-            <div className={styles.monthLabelsRow}>
-              {monthLabels.map(({ label, width, startWeek }) => (
-                <span key={startWeek} className={styles.monthLabel} style={{ width }}>
-                  {label}
-                </span>
-              ))}
-            </div>
+            <MonthLabel monthLabels={monthLabels} />
 
-            {/* 주 그리드 */}
             <div className={styles.weeks}>
               {weeks.map((week, wi) => (
                 <div key={wi} className={styles.week}>
@@ -104,38 +75,7 @@ function Heatmap({ games }: Props) {
         </div>
       </div>
 
-      {/* 범례 */}
-      <div className={styles.legendWrapper}>
-        {/* 결과 색상 */}
-        <div className={styles.legendGroup}>
-          <span className={styles.legendText}>패</span>
-          {(['big-lose', 'lose', 'draw', 'win', 'big-win'] as const).map((v) => (
-            <div key={v} className={styles.legendCellVariants[v]} />
-          ))}
-          <span className={styles.legendText}>승</span>
-        </div>
-
-        <div className={styles.legendSep} />
-
-        {/* 경기 없음 / 예정됨 */}
-        <div className={styles.legendGroup}>
-          <div className={styles.legendCellVariants.empty} />
-          <span className={styles.legendText}>없음</span>
-        </div>
-
-        <div className={styles.legendGroup}>
-          <div className={styles.legendCellVariants.scheduled} />
-          <span className={styles.legendText}>예정</span>
-        </div>
-
-        <div className={styles.legendSep} />
-
-        {/* 직관 */}
-        <div className={styles.legendGroup}>
-          <div className={styles.legendCellVariants.visited} />
-          <span className={styles.legendText}>직관</span>
-        </div>
-      </div>
+      <Legend />
 
       {/* Tooltip */}
       {hoveredDay &&
@@ -146,7 +86,7 @@ function Heatmap({ games }: Props) {
           </div>,
           document.body,
         )}
-    </div>
+    </>
   );
 }
 

--- a/src/views/baseball/ui/Heatmap/index.tsx
+++ b/src/views/baseball/ui/Heatmap/index.tsx
@@ -8,10 +8,10 @@ import { Game } from '@/entity/baseball';
 import { useMounted } from '@/shared/hooks';
 
 import DayCell from './DayCell';
-import { buildHeatmapGrid, DAY_LABEL_MAP } from './grid';
 import * as styles from './index.css';
 import TooltipContent from './TooltipContent';
 import { HeatmapDay } from './types';
+import { buildHeatmapGrid, DAY_LABEL_MAP } from './utils';
 
 interface Props {
   games: Game[];
@@ -117,10 +117,15 @@ function Heatmap({ games }: Props) {
 
         <div className={styles.legendSep} />
 
-        {/* 경기 없음 */}
+        {/* 경기 없음 / 예정됨 */}
         <div className={styles.legendGroup}>
           <div className={styles.legendCellVariants.empty} />
           <span className={styles.legendText}>없음</span>
+        </div>
+
+        <div className={styles.legendGroup}>
+          <div className={styles.legendCellVariants.scheduled} />
+          <span className={styles.legendText}>예정</span>
         </div>
 
         <div className={styles.legendSep} />

--- a/src/views/baseball/ui/Heatmap/styles.ts
+++ b/src/views/baseball/ui/Heatmap/styles.ts
@@ -1,0 +1,13 @@
+import { CellVariant } from './types';
+
+type Hexcode = `#${string}`;
+export const CELL_COLORS: Record<CellVariant, Hexcode> = {
+  'big-win': '#FF6600',
+  win: '#FFAA77',
+  draw: '#e8d5b0',
+  lose: '#90B8D8',
+  'big-lose': '#5A8AB0',
+  canceled: '#E0E0E0',
+  scheduled: '#C8C8C8',
+  empty: '#EBEBEB',
+};

--- a/src/views/baseball/ui/Heatmap/types.ts
+++ b/src/views/baseball/ui/Heatmap/types.ts
@@ -1,11 +1,11 @@
 import { Game, GameResult } from '@/entity/baseball';
 
-export type CellVariant = GameResult | 'canceled' | 'scheduled' | 'empty' | 'future-empty';
+export type CellVariant = GameResult | 'canceled' | 'scheduled' | 'empty';
+export type GameInfo = Exclude<CellVariant, 'empty'>;
 
 export interface HeatmapDay {
   date: string; // 'YYYY-MM-DD'
   games: Game[];
-  isFuture: boolean;
 }
 
 export type HeatmapWeek = HeatmapDay[];

--- a/src/views/baseball/ui/Heatmap/utils.ts
+++ b/src/views/baseball/ui/Heatmap/utils.ts
@@ -1,15 +1,16 @@
 import { Game } from '@/entity/baseball';
 import { BaseballConfig } from '@/shared/config';
+import { toLocalDateStr } from '@/shared/lib/date';
 
-import { HeatmapDay, HeatmapGrid, HeatmapWeek } from './types';
+import { CellVariant, GameInfo, HeatmapDay, HeatmapGrid, HeatmapWeek } from './types';
 
 export const CELL_SIZE = 16;
 const WEEKS = BaseballConfig.heatmapWeeks;
 
 export const DAY_LABEL_MAP: Record<number, string> = {
-  1: '월',
-  3: '수',
-  5: '금',
+  1: '화',
+  4: '금',
+  6: '일',
 };
 
 const MONTH_NAMES = [
@@ -27,23 +28,16 @@ const MONTH_NAMES = [
   '12월',
 ];
 
-const toLocalDateStr = (date: Date): string => {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
-};
-
 export const buildHeatmapGrid = (games: Game[]): HeatmapGrid => {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  // 이번 주 토요일 (grid 끝)
+  // 이번 주 일요일 (grid 끝, 월~일 기준)
   const endDow = today.getDay();
   const end = new Date(today);
-  end.setDate(today.getDate() + (6 - endDow));
+  end.setDate(today.getDate() + ((7 - endDow) % 7));
 
-  // WEEKS주 전 일요일 (grid 시작)
+  // WEEKS주 전 월요일 (grid 시작)
   const start = new Date(end);
   start.setDate(end.getDate() - (WEEKS - 1) * 7 - 6);
 
@@ -73,11 +67,11 @@ export const buildHeatmapGrid = (games: Game[]): HeatmapGrid => {
     for (let dow = 0; dow < 7; dow++) {
       const dateStr = toLocalDateStr(cursor);
       const isFuture = cursor > today;
+      const allGames = gamesByDate.get(dateStr) ?? [];
 
       week.push({
         date: dateStr,
-        games: isFuture ? [] : (gamesByDate.get(dateStr) ?? []),
-        isFuture,
+        games: isFuture ? allGames.filter((g) => g.status === 'scheduled') : allGames,
       } satisfies HeatmapDay);
 
       cursor.setDate(cursor.getDate() + 1);
@@ -96,4 +90,15 @@ export const buildHeatmapGrid = (games: Game[]): HeatmapGrid => {
   });
 
   return { weeks, monthLabels };
+};
+
+export const getCellVariant = (game: Game): CellVariant => {
+  if (game.status === 'canceled') return 'canceled';
+  if (game.status === 'scheduled') return 'scheduled';
+  if (game.result === null) return 'empty';
+  return game.result;
+};
+
+export const hasGameInfo = (cellVariant: CellVariant): cellVariant is GameInfo => {
+  return cellVariant !== 'empty';
 };

--- a/src/views/baseball/ui/Heatmap/utils.ts
+++ b/src/views/baseball/ui/Heatmap/utils.ts
@@ -4,15 +4,6 @@ import { toLocalDateStr } from '@/shared/lib/date';
 
 import { CellVariant, GameInfo, HeatmapDay, HeatmapGrid, HeatmapWeek } from './types';
 
-export const CELL_SIZE = 16;
-const WEEKS = BaseballConfig.heatmapWeeks;
-
-export const DAY_LABEL_MAP: Record<number, string> = {
-  1: '화',
-  4: '금',
-  6: '일',
-};
-
 const MONTH_NAMES = [
   '1월',
   '2월',
@@ -28,6 +19,8 @@ const MONTH_NAMES = [
   '12월',
 ];
 
+const CELL_SIZE = 16;
+const WEEKS = BaseballConfig.heatmapWeeks;
 export const buildHeatmapGrid = (games: Game[]): HeatmapGrid => {
   const today = new Date();
   today.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## 👀 변경된 부분
### 히트맵 주요 로직 변경
- 마지막 셀을 오늘 날짜가 아닌 이번주 일요일로 변경 (셀 채움)
- 열을 일-토가 아닌 월-일로 변경 및 요일 레이블 화/금/일로 변경 (시리즈 파악 용이)
- 예정된 경기 표시
- 호버 시 툴팁에 홈/원정이 아닌 구장 정보 표기

### 리팩터링 및 기타 수정
- 컴포넌트 역할 별 파일 분리 (+css)
- 게임 승패 및 결과 정보를 저장하는 `GameInfo` 타입 추가
- 일부 로직 공통화
- 콘솔 로그 제거

## 🖼️ 이미지

| mobile | tablet | desktop |
| ------ | ------ | ------- |
|    ![iPhone 12 Pro-1774448667490](https://github.com/user-attachments/assets/96e44b52-6005-490b-bb64-8e3a1c9f8fcd)    |  ![iPad-1774448669009](https://github.com/user-attachments/assets/8b366457-94a8-4447-855e-1393036d2230)      |    ![MacBook Pro-1774448670548](https://github.com/user-attachments/assets/268c6dcc-518c-49f8-898e-bc5af4445dd9)     |

## 📚 참고 자료



